### PR TITLE
Make notebook use environment variables as present on eurodatacube.com

### DIFF
--- a/jupyter/main.ipynb
+++ b/jupyter/main.ipynb
@@ -33,17 +33,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# load credentials from environment variables\n",
-    "%load_ext dotenv\n",
-    "%dotenv"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -72,6 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
     "import shapely.geometry\n",
     "import IPython.display\n",
     "import matplotlib.pyplot as plt\n",
@@ -128,9 +118,9 @@
     }
    ],
    "source": [
-    "sh_credentials = dict(sh_client_id='your client id',\n",
-    "                      sh_client_secret='your client secret',\n",
-    "                      instance_id='your instance id')\n",
+    "sh_credentials = dict(sh_client_id=os.environ['SH_CLIENT_ID'],\n",
+    "                      sh_client_secret=os.environ['SH_CLIENT_SECRET'],\n",
+    "                      instance_id=os.environ['SH_INSTANCE_ID'])\n",
     "\n",
     "task.set_credentials(**sh_credentials)"
    ]


### PR DESCRIPTION
The previous version tried to load enviromental variables from the file
`.env`, which only exists in the jupyterhub environment. For EDC apps,
environment variables are directly injected.